### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: Lint Code Base
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/anonymous174174/404brain-not-found/security/code-scanning/2](https://github.com/anonymous174174/404brain-not-found/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since this is a linting workflow, it likely only needs `contents: read` to access the repository's code. We will add this block immediately after the `name` field to apply it to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
